### PR TITLE
fix error handling with jshint, will now block build from occuring

### DIFF
--- a/cp/gulpfile.js
+++ b/cp/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('concatInterface', function() {
   .pipe(gulp.dest('./tmp'));
 });
 
-gulp.task('jsBrowserify', ['concatInterface'], function() {
+gulp.task('jsBrowserify', ['concatInterface', 'jshint'], function() {
   return browserify({ entries: ['./tmp/allConcat.js'] })
   .bundle()
   .pipe(source('app.js'))
@@ -73,7 +73,7 @@ gulp.task("build", ['clean'], function(){
   gulp.start('cssBuild')
 });
 
-gulp.task('jsBuild', ['jsBrowserify', 'jshint'], function() {
+gulp.task('jsBuild', ['jsBrowserify'], function() {
   browserSync.reload();
   gulp.start('gitStatus');
 });
@@ -106,7 +106,8 @@ gulp.task('serve', function() {
 gulp.task('jshint', function(){
   return gulp.src(['js/*.js'])
   .pipe(jshint())
-  .pipe(jshint.reporter('default'));
+  .pipe(jshint.reporter('default'))
+  .pipe(jshint.reporter('fail'));
 });
 
 gulp.task('cssBuild', function() {


### PR DESCRIPTION
Give it a test run, I got it working on my gulpfile set up. Gulp is built to not run a task if a required task "fails" or reports an error. Our jshint gulp stream was not finished. .pipe(jshint.reporter('default')) only sets the styling for a report to terminal (and posts it there I think) but does not actually return an error to gulp. Adding the .pipe(jshint.reporter('fail')) will cause jshint to actually fail when there is an error. 

I have to say, the docs for jshint are really shitty, I'm not surprised a lot of people have had this error.

See you tomorrow.
